### PR TITLE
sshtarget class

### DIFF
--- a/src/yaesm/sshtarget.py
+++ b/src/yaesm/sshtarget.py
@@ -13,7 +13,7 @@ class SSHTarget:
     used for authentication to the server.
 
     Example::
-        sshtarget = SSHTarget("ssh://p22:fred@fredserver:/home/backups", "/home/larry/.ssh/id_rsa")
+        sshtarget = SSHTarget("ssh://p22:fred@fredserver:/home/backups", Path("/home/larry/.ssh/id_rsa"))
         returncode, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}")
     """
     def __init__(self, target_spec, key:Path):

--- a/src/yaesm/sshtarget.py
+++ b/src/yaesm/sshtarget.py
@@ -1,0 +1,56 @@
+import paramiko
+import re
+from pathlib import Path
+
+class SSHTargetException(Exception):
+    ...
+
+class SSHTarget:
+    """The SSHTarget class manages connections to SSH servers using paramiko.
+    An SSHTarget is defined by its "target spec" which is a string of the form
+    ssh://p$PORT:$USER@HOST:$PATH. To initialize a SSHTarget you must pass the
+    constructor both a target spec, and the path to a private key that will be
+    used for authentication to the server.
+
+    Example::
+        sshtarget = SSHTarget("ssh://p22:fred@fredserver:/home/backups", "/home/larry/.ssh/id_rsa")
+        returncode, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}")
+    """
+    def __init__(self, target_spec, key:Path):
+        sshtarget_re = re.compile("^ssh://p([0-9]+):([^@]+)@([^:]+):(.+)$")
+        re_result = sshtarget_re.match(target_spec)
+        if re_result:
+            self.port = int(re_result.group(1))
+            self.user = re_result.group(2)
+            self.host = re_result.group(3)
+            self.path = Path(re_result.group(4))
+            self.key = key
+            self._client = paramiko.SSHClient()
+            self._client.set_missing_host_key_policy(paramiko.WarningPolicy)
+        else:
+            raise SSHTargetException(f"invalid SSHTarget spec: {target_spec}")
+
+    def exec_command(self, command):
+        """Execute 'command' on SSHTarget using paramiko.client.exec_command().
+        Automatically establishes a connection using paramiko.client.connect(),
+        that authenticates with the SSHTarget key.
+
+        Example::
+            returncode, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}")
+        """
+        if self._client.get_transport() is None or not self._client.get_transport().is_active():
+            self._client.connect(
+                self.host,
+                username=self.user,
+                port=self.port,
+                key_filename=str(self.key),
+                auth_timeout=60,
+                timeout=None,
+                allow_agent=False,
+                look_for_keys=False
+            )
+        _, stdout, stderr = self._client.exec_command(command)
+        returncode = stdout.channel.recv_exit_status()
+        stdout = stdout.read().decode("utf-8")
+        stderr = stderr.read().decode("utf-8")
+        return [returncode, stdout, stderr]

--- a/tests/yaesm/test_sshtarget.py
+++ b/tests/yaesm/test_sshtarget.py
@@ -1,0 +1,31 @@
+import pytest
+from yaesm.sshtarget import SSHTarget, SSHTargetException
+from pathlib import Path
+
+@pytest.fixture
+def sshtarget(localhost_server):
+    user = localhost_server["user"]
+    key = localhost_server["key"]
+    target_spec = f"ssh://p22:{user.pw_name}@localhost:{user.pw_dir}"
+    sshtarget = SSHTarget(target_spec, key)
+    return sshtarget
+
+def test_sshtarget_constructor(localhost_server):
+    user = localhost_server["user"]
+    key  = localhost_server["key"]
+
+    with pytest.raises(SSHTargetException):
+        SSHTarget("INVALID_SSHTARGET_SPEC", key)
+
+    target = SSHTarget(f"ssh://p2222:{user.pw_name}@localhost:/a/random/path", key)
+    assert target.port == 2222
+    assert target.user == user.pw_name
+    assert target.host == "localhost"
+    assert target.path == Path("/a/random/path")
+    assert target.key  == key
+
+def test_sshtarget_connection_and_command_execution(sshtarget):
+    returncode, stdout, stderr = sshtarget.exec_command("whoami && echo foo 1>&2 && exit 12")
+    assert returncode == 12
+    assert stdout == f"{sshtarget.user}\n"
+    assert stderr == "foo\n"


### PR DESCRIPTION
This PR adds a class named `SSHTarget` that gives us an interface for connecting to SSH servers and executing commands on those servers. Hopefully the docstring for the `SSHTarget` class explains how it works fully:
```
    """The SSHTarget class manages connections to SSH servers using paramiko.
    An SSHTarget is defined by its "target spec" which is a string of the form
    ssh://p$PORT:$USER@HOST:$PATH. To initialize a SSHTarget you must pass the
    constructor both a target spec, and the path to a private key that will be
    used for authentication to the server.

    Example::
        sshtarget = SSHTarget("ssh://p22:fred@fredserver:/home/backups", Path("/home/larry/.ssh/id_rsa"))
        returncode, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}")
    """
```

The SSHTarget class implements a method called `exec_command` that is a wrapper over paramikos [exec_command](https://docs.paramiko.org/en/latest/api/client.html#paramiko.client.SSHClient.exec_command), that first establishes a connection to the server with paramikos [connect](https://docs.paramiko.org/en/latest/api/client.html#paramiko.client.SSHClient.connect) method. 

By the way, I used the [paramiko.client.WarningPolicy](https://docs.paramiko.org/en/latest/api/client.html#paramiko.client.WarningPolicy) for when we encounter an unknown [SSH host key](https://serverfault.com/questions/1132148/what-is-the-host-key-the-one-from-ssh-connection-and-how-is-it-different-from). This does leave users vulnerable to mitm attacks, but at least will give a warning about it (which we will log). I had trouble figuring out how to manually add host keys to solve this problem (it is definitely possible though).

# OpenSSH & paramiko

SSHTarget uses paramiko for SSH. I would prefer that we use OpenSSH in the future though, as I feel that is what users would expect, and paramiko does not have 1-to-1 support for OpenSSH config files. This means that peoples Hosts that they define in their ssh config files may not work with yaesm which doesn't make sense (see [here](https://stackoverflow.com/a/64739365)). There is a python package called [openssh-wrapper](https://pypi.org/project/openssh-wrapper/) that would be nice to use, however it is missing some features we need, most importantly the ability to pass options to ssh like you would with `-o` flags. Somebody did however fork openssh-wrapper and added this (among other) features. However this fork is not available on PyPI. I contacted the author about the possibility of this package being released on PyPI but I haven't heard back yet (you can see that discussion [here](https://github.com/NetAngels/openssh-wrapper/issues/17)). If we don't hear back on that soon we could fork the fork (haha) and release it to PyPI under a new name. We could also just use `subprocess` for our ssh needs.