### PR TITLE
add return_files option to SSHTarget.exec_command()

### DIFF
--- a/src/yaesm/sshtarget.py
+++ b/src/yaesm/sshtarget.py
@@ -1,5 +1,6 @@
 import paramiko
 import re
+import subprocess
 from pathlib import Path
 
 class SSHTargetException(Exception):
@@ -30,13 +31,23 @@ class SSHTarget:
         else:
             raise SSHTargetException(f"invalid SSHTarget spec: {target_spec}")
 
-    def exec_command(self, command):
+    def exec_command(self, command, return_files=False):
         """Execute 'command' on SSHTarget using paramiko.client.exec_command().
-        Automatically establishes a connection using paramiko.client.connect(),
+        Automatically establishes a connection using paramiko.client.connect()
         that authenticates with the SSHTarget key.
+
+        If 'return_files' == False, then return a list containing
+        [returncode, stdout_str, stderr_str], where stdout_str and stderr_str are
+        utf-8 strings of the remote generated STDOUT and STDERR.
+
+        Otherwise if 'return_files' == True, then return [stdin, stdout, stderr],
+        where stdin, stdout, and stderr are Python file-like objects representing
+        the commands STDIN, STDOUT, and STDERR (just like paramiko.exec_command()
+        returns).
 
         Example::
             returncode, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}")
+            stdin, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}", return_data=False)
         """
         if self._client.get_transport() is None or not self._client.get_transport().is_active():
             self._client.connect(
@@ -49,8 +60,11 @@ class SSHTarget:
                 allow_agent=False,
                 look_for_keys=False
             )
-        _, stdout, stderr = self._client.exec_command(command)
-        returncode = stdout.channel.recv_exit_status()
-        stdout = stdout.read().decode("utf-8")
-        stderr = stderr.read().decode("utf-8")
-        return [returncode, stdout, stderr]
+        stdin, stdout, stderr = self._client.exec_command(command)
+        if return_files:
+            return [stdin, stdout, stderr]
+        else:
+            returncode = stdout.channel.recv_exit_status()
+            stdout = stdout.read().decode("utf-8")
+            stderr = stderr.read().decode("utf-8")
+            return [returncode, stdout, stderr]

--- a/tests/yaesm/test_sshtarget.py
+++ b/tests/yaesm/test_sshtarget.py
@@ -25,7 +25,11 @@ def test_sshtarget_constructor(localhost_server):
     assert target.key  == key
 
 def test_sshtarget_connection_and_command_execution(sshtarget):
-    returncode, stdout, stderr = sshtarget.exec_command("whoami && echo foo 1>&2 && exit 12")
+    returncode, stdout_str, stderr_str = sshtarget.exec_command("whoami && echo foo 1>&2 && exit 12")
     assert returncode == 12
-    assert stdout == f"{sshtarget.user}\n"
-    assert stderr == "foo\n"
+    assert stdout_str == f"{sshtarget.user}\n"
+    assert stderr_str == "foo\n"
+
+    stdin, stdout, stderr = sshtarget.exec_command("echo foo && echo bar 1>&2", return_files=True)
+    assert stdout.read().decode("utf-8") == "foo\n"
+    assert stderr.read().decode("utf-8") == "bar\n"


### PR DESCRIPTION
This PR adds a `return_files` option to `SSHTarget.exec_command()`, which allows you to choose if you want to be returned python file objects for STDIN, STDOUT, and STDERR (`return_files=True`), or if you want the processes returncode, and stdout and stderr as utf-8 encoded strings (`return_files=False`).

I updated the docstring of `exec_command` which should document everything clearly. I also added tests for this functionality to `test_sshtarget.py`.