### PR TITLE
Testing improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ $ ./docker-pytest.sh -H ### print docker-pytest.sh help message
 $ ./docker-pytest.sh ./tests
 $ ./docker-pytest.sh $PYTEST_ARGS
 ```
+
+Note that all tests assume they are running in a containerized environment. It is NOT SAFE to run the test suite without the use of `docker-pytest.sh`. See `tests/README` for more information about the test suite.

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,10 @@
+All tests can assume that they are running as root in a Debian Linux Docker
+container.
+
+The yaesm test suite is assumed to be ran in a Docker container. For this reason
+tests don't have to worry about cleaning up state, which allows for easier
+debugging. It is very unwise to run the test suite outside of a Docker container
+as your system may get mangled. Always use docker-pytest.sh to run the test
+suite.
+
+See docker-pytest.sh and Dockerfile_pytest for more information.


### PR DESCRIPTION
This PR removes state cleanup from the fixtures defined in `tests/conftest.py`. I did this because cleaning up the state isn't necessary when we run the test suite in a Docker container. Leaving the state behind makes debugging test problems significantly easier. 

However, because the state is not cleaned up, this makes it very unwise to run the test suite outside of a Docker container as the system will be modified (new users created, files left around, etc). I added a file `tests/README` that documents this, and updated the repositories main `README.md` to document this as well. 