### PR TITLE
use openssh instead of paramiko

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-bcrypt==4.2.0
-cffi==1.17.1
-cryptography==43.0.3
-paramiko==3.5.0
-pycparser==2.22
-PyNaCl==1.5.0

--- a/src/yaesm/sshtarget.py
+++ b/src/yaesm/sshtarget.py
@@ -1,69 +1,57 @@
-import paramiko
 import re
+import shlex
 from pathlib import Path
 
 class SSHTargetException(Exception):
     ...
 
 class SSHTarget:
-    """The SSHTarget class manages connections to SSH servers using paramiko.
+    """The SSHTarget class manages connections to SSH servers using openssh.
     An SSHTarget is defined by its "target spec" which is a string of the form
-    ssh://p$PORT:$USER@HOST:$PATH. To initialize a SSHTarget you must pass the
+    ssh://p$PORT:$HOST:$PATH. $HOST can either be a host defined in a
+    .ssh/config file, or can be a host specification of the form $USER@$HOST.
+    The p$PORT: token is optional. To initialize a SSHTarget you must pass the
     constructor both a target spec, and the path to a private key that will be
     used for authentication to the server.
 
     Example::
-        sshtarget = SSHTarget("ssh://p22:fred@fredserver:/home/backups", Path("/home/larry/.ssh/id_rsa"))
-        returncode, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}")
+        sshtarget = SSHTarget("ssh://p22:fred@fredserver:/backups", Path("/home/larry/.ssh/id_rsa"))
+        sshtarget = SSHTarget("ssh://fredhost:/backups, Path("/home/larry/.ssh/id_rsa"))
     """
     def __init__(self, target_spec, key:Path):
-        sshtarget_re = re.compile("^ssh://p([0-9]+):([^@]+)@([^:]+):(.+)$")
-        re_result = sshtarget_re.match(target_spec)
-        if re_result:
-            self.port = int(re_result.group(1))
-            self.user = re_result.group(2)
-            self.host = re_result.group(3)
-            self.path = Path(re_result.group(4))
-            self.key = key
-            self._client = paramiko.SSHClient()
-            self._client.set_missing_host_key_policy(paramiko.WarningPolicy)
+        self.key = Path(key)
+        target_spec_re = re.compile("^ssh://(p[0-9]+:)?([^:]+):(.+)$")
+        user_host_re = re.compile("^([^@]+)@(.+)$")
+        if target_spec_re_result := target_spec_re.match(target_spec):
+            port = target_spec_re_result.group(1)
+            self.port = None if port is None else int(port[1:-1]) # strip off leading 'p' and trailing ':' from 'port'
+            self.host = target_spec_re_result.group(2)
+            self.path = Path(target_spec_re_result.group(3))
+            if user_host_re_result := user_host_re.match(self.host):
+                self.user = user_host_re_result.group(1)
+                self.host = user_host_re_result.group(2)
+            else:
+                self.user = None
         else:
             raise SSHTargetException(f"invalid SSHTarget spec: {target_spec}")
 
-    def exec_command(self, command, return_files=False):
-        """Execute 'command' on SSHTarget using paramiko.client.exec_command().
-        Automatically establishes a connection using paramiko.client.connect()
-        that authenticates with the SSHTarget key.
+    def openssh_cmd(self, command, extra_opts="", quote_command=True):
+        """Returns a string of an openssh command that executes 'command' on the
+        SSHTargets remote server. The returned openssh command enforces key-based
+        auth, host key checking, and ssh multiplexing.
 
-        If 'return_files' == False, then return a list containing
-        [returncode, stdout_str, stderr_str], where stdout_str and stderr_str are
-        utf-8 strings of the remote generated STDOUT and STDERR.
+        If 'quote_command' is true then the 'command' arg is quoted with shlex.quote().
 
-        Otherwise if 'return_files' == True, then return [stdin, stdout, stderr],
-        where stdin, stdout, and stderr are Python file-like objects representing
-        the commands STDIN, STDOUT, and STDERR (just like paramiko.exec_command()
-        returns).
+        The caller can pass extra openssh opts by setting 'extra_opts' to a string
+        containing openssh options.
 
-        Example::
-            returncode, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}")
-            stdin, stdout, stderr = sshtarget.exec_command(f"ls -l {sshtarget.path}", return_data=False)
+        Example usage::
+            p = subprocess.Popen(sshtarget.openssh_command("btrfs send /home/fred") + " | btrfs receive /home-backups/yaesm-backup@1999_05_13_23:59", shell=True, encoding="utf-8", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = p.communicate()
+            returncode = p.returncode
         """
-        if self._client.get_transport() is None or not self._client.get_transport().is_active():
-            self._client.connect(
-                self.host,
-                username=self.user,
-                port=self.port,
-                key_filename=str(self.key),
-                auth_timeout=60,
-                timeout=None,
-                allow_agent=False,
-                look_for_keys=False
-            )
-        stdin, stdout, stderr = self._client.exec_command(command)
-        if return_files:
-            return [stdin, stdout, stderr]
-        else:
-            returncode = stdout.channel.recv_exit_status()
-            stdout = stdout.read().decode("utf-8")
-            stderr = stderr.read().decode("utf-8")
-            return [returncode, stdout, stderr]
+        if quote_command:
+            command = shlex.quote(command)
+        host = self.host if self.user is None else f"{self.user}@{self.host}"
+        port_opt = "" if self.port is None else f"-p {self.port}"
+        return f"ssh {extra_opts} -q -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o ControlMaster=auto -o 'ControlPath=~/.ssh/yaesm-controlmaster-%r@%h:%p' -o ControlPersist=310 -i '{self.key}' {port_opt} '{host}' {command}"


### PR DESCRIPTION
This PR swaps out paramiko for openssh. I decided to go with the strategy to just use subprocess for our ssh needs. To do this I added a method to the SSHTarget class named `openssh_cmd` that outputs a string containing an openssh command to authenticate and execute code on the remote server. The command that is outputted enforces key-bases auth, strict hostkey checking, and multiplexing. 

Everything should be well documented so see `sshtarget.py` for more information.