### PR TITLE
Implement the BackendBase class

### DIFF
--- a/src/yaesm/backend/backendbase.py
+++ b/src/yaesm/backend/backendbase.py
@@ -1,29 +1,72 @@
 import abc
+from typing import final
+from pathlib import Path
+
+import yaesm.backup as bckp
+from yaesm.timeframe import Timeframe
+from yaesm.sshtarget import SSHTarget
 
 class BackendBase(abc.ABC):
-    """Abstract base class for execution backend classes such as RsyncBackend and BtrfsBackend."""
+    """Abstract base class for execution backend classes such as RsyncBackend
+    and BtrfsBackend. An actual backend class inherits from BackendBase, and
+    implements the methods '_exec_backup_local_to_local()',
+    '_exec_backup_local_to_remote()', 'exec_backup_remote_to_local()',
+    '_delete_backups_local()', and '_delete_backups_remote()' must be
+    implemented. Any code using a backend only needs to interact with the
+    'do_backup()' method, which is defined in this class.
+    """
+
+    @final
+    def do_backup(self, backup:bckp.Backup, timeframe:Timeframe):
+        """Perform a backup of 'backup' for the Timeframe 'timeframe'."""
+        src_dir = backup.src_dir
+        if isinstance(backup.dst_dir, SSHTarget):
+            dst_dir = backup.dst_dir.with_path(dst_dir.path.joinpath(timeframe.name))
+        else:
+            dst_dir = dst_dir.joinpath(timeframe.name)
+        if backup.backup_type == "local_to_local":
+            self.exec_backup_local_to_local(src_dir, dst_dir)
+        elif backup.backup_type == "local_to_remote":
+            self.exec_backup_local_to_remote(src_dir, dst_dir)
+        else: # remote_to_local
+            self.exec_backup_remote_to_local(timeframe)
+        backups = bckp.backups_collect(dst_dir) # sorted newest to oldest
+        to_delete = []
+        while len(backups) > timeframe.keep():
+            to_delete.append(backups.pop())
+        if to_delete:
+            if (isinstance(dst_dir, SSHTarget)):
+                self.delete_backups_remote(*to_delete)
+            else:
+                self.delete_backups_local(*to_delete)
 
     @abc.abstractmethod
-    def execute_backup(self, src_dir, dst_dir):
-        """Execute a single backup of src_dir to dst_dir."""
+    def _exec_backup_local_to_local(self, src_dir:Path, dst_dir:Path):
+        """Execute a single local to local backup of 'src_dir' and place it in
+        'dst_dir'. Places that backup in 'dst_dir' literally. Does not perform
+        any cleanup."""
         ...
 
     @abc.abstractmethod
-    def cleanup_backup(self, src_dir, dst_dir):
-        """Cleanup system after executing a backup with execute_backup(src_dir, dst_dir)."""
+    def _exec_backup_local_to_remote(self, src_dir:Path, dst_dir:SSHTarget):
+        """Execute a single local to remote backup of 'src_dir' and place it in
+        the SSHTarget 'dst_dir'. Places that backup in the remote 'dst_dir.path'
+        literally. Does not perform any cleanup."""
         ...
 
     @abc.abstractmethod
-    def bootstrap_backup(self, src_dir, dst_dir):
-        """Bootstrap the system to support backups of src_dir to be placed in dst_dir."""
+    def _exec_backup_remote_to_local(self, src_dir:SSHTarget, dst_dir:Path):
+        """Execute a single remote to local backup of the SSHTarget 'src_dir' and
+        place it in 'dst_dir'. Places that backup in 'dst_dir' literally. Does
+        not perform any cleanup."""
         ...
 
     @abc.abstractmethod
-    def backup_is_bootstrapped(self, src_dir, dst_dir):
-        """Return True if the system is ready for a backup of src_dir to dst_dir, and return False otherwise."""
+    def _delete_backups_local(self, *backups):
+        """Delete all the local backups in '*backups' (Paths)."""
         ...
 
     @abc.abstractmethod
-    def backup_is_viable(self, src_dir, dst_dir):
-        """Return True if a backup from src_dir to dst_dir is viable, and return False otherwise."""
+    def _delete_backups_remote(self, *backups):
+        """Delete all the remote backups in '*backups' (SSHTargets)."""
         ...


### PR DESCRIPTION
This PR fully implements the `BackendBase` class. The code in backendbase.py is well documented and should provide full details of how it works. All backends (such as the btrfs and rsync backends) will inherit from this class. The only function that will be used by callers of a backend is the `do_backup()` function which is defined in `BackendBase`. To implement a backend you just have to define the `abc.abstractmethod`'s present in `BackendBase`. Note that I did not provide a test script for `BackendBase`. All the testing for backends will happen for the actual backend classes. Also note that `BackendBase` uses timeframe (see #11), even though it is not finished yet.

I am very close to finishing (and testing) the btrfs backend, though it is not quite ready yet.