### PR TITLE
make backups_collect() return SSHTargets

### DIFF
--- a/tests/test_yaesm/test_backup.py
+++ b/tests/test_yaesm/test_backup.py
@@ -2,7 +2,16 @@ import pytest
 import yaesm.backup as bckp
 from yaesm.sshtarget import SSHTarget
 
-def test_backup_to_datetime():
+def test_backup_to_datetime(sshtarget):
+    # accept full paths
+    dt = bckp.backup_to_datetime("/some/path/yaesm-backup@1999_05_13_10:30")
+    dt.year == 1999
+    dt.month == 5
+    dt.day == 13
+    dt.hour == 10
+    dt.minute == 30
+
+    # accept just basename
     dt = bckp.backup_to_datetime("yaesm-backup@1999_05_13_10:30")
     dt.year == 1999
     dt.month == 5
@@ -10,8 +19,8 @@ def test_backup_to_datetime():
     dt.hour == 10
     dt.minute == 30
 
-    # also should accept full paths
-    dt = bckp.backup_to_datetime("/some/path/yaesm-backup@1999_05_13_10:30")
+    # accept SSHTarget
+    dt = bckp.backup_to_datetime(sshtarget.with_path("/some/path/yaesm-backup@1999_05_13_10:30"))
     dt.year == 1999
     dt.month == 5
     dt.day == 13
@@ -60,4 +69,5 @@ def test_backups_collect(path_generator, sshtarget):
     for bn in backup_basenames:
         target.joinpath(bn).mkdir(parents=True, exist_ok=True)
     sshtarget.path = target
-    assert bckp.backups_collect(sshtarget) == list(map(lambda bn: target.joinpath(bn), backup_basenames))
+    got = bckp.backups_collect(sshtarget)
+    assert list(map(lambda sshtarget: sshtarget.path, got)) == list(map(lambda bn: target.joinpath(bn), backup_basenames))


### PR DESCRIPTION
This PR makes the `backups_collect()` function, when collecting from an SSHTarget, return a list of SSHTargets for the collected backups. Before this PR `backups_collect()` just returned Paths to the backups that represented paths on the remote system.