### PR TITLE
backup timeframe name merge

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,9 +218,9 @@ def sshtarget(sshtarget_generator):
 
 @pytest.fixture
 def random_timeframe_generator(random_timeframe_times_generator, random_timeframe_minutes_generator, random_timeframe_weekdays_generator, random_timeframe_monthdays_generator, random_timeframe_yeardays_generator):
-    """Fixture for generating a random Timeframe."""
+    """Fixture for generating random Timeframes."""
     def generator(tframe_type=None, keep=None, minutes=None, times=None, weekdays=None, monthdays=None, yeardays=None) -> Timeframe:
-        tframe_type = random.choice(Timeframe.valid_tframe_types()) if tframe_type is None else tframe_type
+        tframe_type = random.choice(Timeframe.tframe_types()) if tframe_type is None else tframe_type
         keep        = random.randint(0,10) if keep is None else keep
         minutes     = random_timeframe_minutes_generator(random.randint(0,5)) if minutes is None else minutes
         times       = random_timeframe_times_generator(random.randint(0,5)) if times is None else times
@@ -240,6 +240,13 @@ def random_timeframe_generator(random_timeframe_times_generator, random_timefram
         elif tframe_type == YearlyTimeframe:
             return YearlyTimeframe(keep, times, yeardays)
     return generator
+
+@pytest.fixture
+def random_timeframe(random_timeframe_generator):
+    """Fixture for generating a single random timeframe. See the fixture
+    'random_timeframe_generator' for more information.
+    """
+    return random_timeframe_generator()
 
 @pytest.fixture
 def random_timeframes_generator(random_timeframe_generator):


### PR DESCRIPTION
This PR changes the semantics of yaesm such that backup names now have the name of the backup and the name of the timeframe in the name of the created backup. If, for example, you had a backup named `foo-backup`, that you were taking a `5minute` backup for that is to be placed in the users `/backups/yaesm` directory, then the created backup would be at `/backups/yaesm/yaesm-foo-backup-5minute@1999_05_13_23:59` (if we were taking the backup on 5/13/1999 at midnight). This now allows the user to safely use the same `dst_dir` for multiple backups, and now does not require yaesm to create directories at runtime for the different timeframes.

This required a significant amount of code changes including a bunch of updates to test code.

This PR closes #20.