### PR TITLE
added log tooling

### DIFF
--- a/src/yaesm/logging.py
+++ b/src/yaesm/logging.py
@@ -1,0 +1,58 @@
+# This module is a wrapper over logging. All logging in yaesm should happen
+# through the functions defined in this module.
+
+import logging
+import logging.handlers
+import inspect
+
+class LoggingNotInitializedException(Exception):
+    ...
+
+_logging_initialized = False
+
+def init_logging(stderr=False, logfile=None, syslog=False, syslog_address="/dev/log", level=logging.INFO):
+    """Initialize logging for yaesm. Yaesm can log to any and all of stderr,
+    syslog, and a file. If this function is called multiple times then it will
+    fully re-initialize the logging. If none of 'stderr', 'logfile', or 'syslog'
+    are True, then 'stderr' is set to True.
+    """
+    if not (stderr or logfile or syslog):
+        stderr = True
+    formatter = logging.Formatter(fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    handlers = []
+    if syslog:
+        syslog_handler = logging.handlers.SysLogHandler(address=syslog_address)
+        syslog_handler.setFormatter(formatter)
+        syslog_handler.setLevel(level)
+        handlers.append(syslog_handler)
+    if stderr:
+        stderr_handler = logging.StreamHandler() # defaults to sys.stderr
+        stderr_handler.setFormatter(formatter)
+        stderr_handler.setLevel(level)
+        handlers.append(stderr_handler)
+    if logfile:
+        logfile_handler = logging.FileHandler(logfile, encoding="utf-8")
+        logfile_handler.setFormatter(formatter)
+        logfile_handler.setLevel(level)
+        handlers.append(logfile_handler)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+    for handler in handlers:
+        root_logger.addHandler(handler)
+    global _logging_initialized
+    _logging_initialized = True
+        
+def logger(name=None):
+    """Return a logger with the specified name. If name is None then it defaults
+    to the name of the callers module. If logging has not yet been initialized
+    (i.e. init_logging() has not been invoked), then raise an exception.
+    """
+    global _logging_initialized
+    if not _logging_initialized:
+        raise LoggingNotInitializedException("trying to get logger but logging has not been initialized")
+    if name is None:
+        name = inspect.getmodule(inspect.stack()[1][0]).__name__
+    logger = logging.getLogger(name)
+    return logger

--- a/tests/test_yaesm/test_logging.py
+++ b/tests/test_yaesm/test_logging.py
@@ -1,0 +1,54 @@
+import pytest
+import logging
+import subprocess
+import re
+
+from yaesm.logging import logger, init_logging, LoggingNotInitializedException
+
+def test_raises_logging_not_initialized():
+    with pytest.raises(LoggingNotInitializedException):
+        logger()
+
+def test_init_logging():
+    init_logging(stderr=True)
+    assert len(logger("").handlers) == 1
+    assert logger("").level == logging.INFO
+
+    init_logging(syslog=True, stderr=True, logfile="/var/log/yaesm_test_logging.log", level=logging.DEBUG)
+    assert len(logger("").handlers) == 3
+    assert logger("").level == logging.DEBUG
+
+    init_logging()
+    assert len(logger("").handlers) == 1
+    assert logger("").level == logging.INFO
+
+def test_stderr_logging(capsys):
+    init_logging(stderr=True, level=logging.DEBUG)
+    logger().debug("TEST LOG")
+    assert re.match(".+DEBUG.+TEST LOG$", capsys.readouterr().err)
+
+def test_level_respected(capsys):
+    init_logging(stderr=True) # level defaults to INFO
+    logger().debug("TEST LOG")
+    assert "" == capsys.readouterr().err
+
+    logger().error("TEST LOG")
+    assert re.match(".+ERROR.+TEST LOG$", capsys.readouterr().err)
+
+def test_logfile_logging(path_generator):
+    logfile = path_generator("yaesm_test_logging")
+    init_logging(logfile=logfile)
+    logger().info("TEST LOG")
+    assert logfile.is_file()
+    assert re.match(".+INFO.+TEST LOG$", logfile.read_text())
+
+def test_syslog_logging():
+    init_logging(syslog=True)
+    logger().info("TEST LOG SYSLOG")
+    found_log = False
+    with open("/var/log/syslog", "r") as syslog:
+        for line in syslog:
+            if re.match(".+INFO.+TEST LOG SYSLOG", line):
+                found_log = True
+                break
+    assert found_log

--- a/tests/test_yaesm/test_logging.py
+++ b/tests/test_yaesm/test_logging.py
@@ -52,3 +52,10 @@ def test_syslog_logging():
                 found_log = True
                 break
     assert found_log
+
+def test_multi_dest_logging(capsys, path_generator):
+    logfile = path_generator("yaesm_test_logging")
+    init_logging(stderr=True, logfile=logfile)
+    logger().info("TEST LOG MULTI DEST")
+    assert re.match(".+INFO.+TEST LOG MULTI DEST$", capsys.readouterr().err)
+    assert re.match(".+INFO.+TEST LOG MULTI DEST$", logfile.read_text())


### PR DESCRIPTION
This PR adds (and tests) `yaesm/logging.py` which is a wrapper over Python's [logging](https://docs.python.org/3/library/logging.html). The wrapper makes it easy to set up logging to syslog, stderr, and logfiles. Under normal circumstances yaesm will just log to [syslog](https://en.wikipedia.org/wiki/Syslog), which makes sense for a system daemon such as yaesm. However, it is still nice to have functionality for logging to stderr or an arbitrary file. 

I determined how we should log by studying how similar system level daemons such as NetworkManager and dcron log. NetworkManager has a `--debug` flag, with the following description in its manual: `Do not daemonize, and direct log output to the controlling terminal in addition to syslog.`. Also dcron has a `-L` flag with the following manual entry: `log to specified file instead of syslog.`. Based on these behaviors from NetworkManager and dcron, I determined that by default we should log to syslog, but add options for logging to stderr or a logfile instead.

