### PR TITLE
BackendBase sends along Backup/Timeframe objects to abstract methods

### DIFF
--- a/src/yaesm/backend/backendbase.py
+++ b/src/yaesm/backend/backendbase.py
@@ -25,12 +25,11 @@ class BackendBase(abc.ABC):
         """
         backup_basename = bckp.backup_basename_now(backup, timeframe)
         if backup.backup_type == "local_to_local":
-            self._exec_backup_local_to_local(backup.src_dir, backup.dst_dir.joinpath(backup_basename))
+            self._exec_backup_local_to_local(backup, timeframe)
         elif backup.backup_type == "local_to_remote":
-            backup_path = backup.dst_dir.with_path(backup.dst_dir.path.joinpath(backup_basename))
-            self._exec_backup_local_to_remote(backup.src_dir, backup_path)
+            self._exec_backup_local_to_remote(backup, timeframe)
         else: # remote_to_local
-            self._exec_backup_remote_to_local(backup.src_dir, backup.dst_dir.joinpath(backup_basename))
+            self._exec_backup_remote_to_local(backup, timeframe)
         backups = bckp.backups_collect(backup, timeframe=timeframe) # sorted newest to oldest
         to_delete = []
         while len(backups) > timeframe.keep:
@@ -42,38 +41,35 @@ class BackendBase(abc.ABC):
                 self._delete_backups_local(*to_delete)
 
     @abc.abstractmethod
-    def _exec_backup_local_to_local(self, src_dir:Path, backup_path:Path):
-        """Execute a single local to local backup of 'src_dir' and place it at
-        'backup_path', whos parent dir should be an existing directory on the
-        local system, and whos basename will be the backup name. Does not
-        perform any cleanup.
+    def _exec_backup_local_to_local(self, backup:bckp.Backup, timeframe:Timeframe):
+        """Execute a single local to local backup for the Backup `backup` in the
+        Timeframe `timeframe`. Note that this function does not perform any
+        cleanup.
         """
         ...
 
     @abc.abstractmethod
-    def _exec_backup_local_to_remote(self, src_dir:Path, backup_path:SSHTarget):
-        """Execute a single local to remote backup of 'src_dir' and place it at
-        the SSHTarget 'backup_path', which should have a .path whos parent should
-        be an existing directory on the remote server, and whos basename will
-        be the backup name. Does not perform any cleanup.
+    def _exec_backup_local_to_remote(self, backup:bckp.Backup, timeframe:Timeframe):
+        """Execute a single local to remote backup for the Backup `backup` in
+        the Timeframe `timeframe`. Note that this function does not perform any
+        cleanup.
         """
         ...
 
     @abc.abstractmethod
-    def _exec_backup_remote_to_local(self, src_dir:SSHTarget, backup_path:Path):
-        """Execute a single remote to local backup of the SSHTarget 'src_dir'
-        and place it at the local 'backup_path', whos parent dir should be an
-        existing directory on the local system, and whos basename will be the
-        backup name. Does not perform any cleanup.
+    def _exec_backup_remote_to_local(self, backup:bckp.Backup, timeframe:Timeframe):
+        """Execute a single remote to local backup for the Backup `backup` in
+        the Timeframe `timeframe`. Note that this function does not perform any
+        cleanup.
         """
         ...
 
     @abc.abstractmethod
     def _delete_backups_local(self, *backups):
-        """Delete all the local backups in '*backups' (Paths)."""
+        """Delete all the local backups in `*backups` (Paths)."""
         ...
 
     @abc.abstractmethod
     def _delete_backups_remote(self, *backups):
-        """Delete all the remote backups in '*backups' (SSHTargets)."""
+        """Delete all the remote backups in `*backups` (SSHTargets)."""
         ...

--- a/src/yaesm/backend/btrfsbackend.py
+++ b/src/yaesm/backend/btrfsbackend.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import yaesm.backup as bckp
 from yaesm.sshtarget import SSHTarget
 from yaesm.backend.backendbase import BackendBase
+from yaesm.timeframe import Timeframe
 
 class BtrfsBackend(BackendBase):
     """The btrfs backup execution backend. See BackendBase for more details on
@@ -19,7 +20,9 @@ class BtrfsBackend(BackendBase):
     commands 'btrfs subvolume snapshot', 'btrfs subvolume delete', 'btrfs send',
     and 'btrfs receive'.
     """
-    def _exec_backup_local_to_local(self, src_dir:Path, backup_path:Path):
+    def _exec_backup_local_to_local(self, backup:bckp.Backup, timeframe:Timeframe):
+        src_dir = backup.src_dir
+        backup_path = backup.dst_dir.joinpath(bckp.backup_basename_now(backup, timeframe))
         returncode, _ = _btrfs_take_snapshot_local(src_dir, backup_path, check=False)
         if 0 != returncode:
             bootstrap_snapshot = _btrfs_bootstrap_local_to_local(src_dir, backup_path.parent)
@@ -27,13 +30,17 @@ class BtrfsBackend(BackendBase):
             _btrfs_send_receive_local_to_local(tmp_snapshot, backup_path.parent, parent=bootstrap_snapshot)
             _btrfs_delete_subvolumes_local(tmp_snapshot)
 
-    def _exec_backup_local_to_remote(self, src_dir:Path, backup_path:SSHTarget):
+    def _exec_backup_local_to_remote(self, backup:bckp.Backup, timeframe:Timeframe):
+        src_dir = backup.src_dir
+        backup_path = backup.dst_dir.with_path(backup.dst_dir.path.joinpath(bckp.backup_basename_now(backup, timeframe)))
         bootstrap_snapshot = _btrfs_bootstrap_local_to_remote(src_dir, backup_path.with_path(backup_path.path.parent))
         _, tmp_snapshot = _btrfs_take_snapshot_local(src_dir, src_dir.joinpath(backup_path.path.name))
         _btrfs_send_receive_local_to_remote(tmp_snapshot, backup_path.with_path(backup_path.path.parent), parent=bootstrap_snapshot)
         _btrfs_delete_subvolumes_local(tmp_snapshot)
 
-    def _exec_backup_remote_to_local(self, src_dir:SSHTarget, backup_path:Path):
+    def _exec_backup_remote_to_local(self, backup:bckp.Backup, timeframe:Timeframe):
+        src_dir = backup.src_dir
+        backup_path = backup.dst_dir.joinpath(bckp.backup_basename_now(backup, timeframe))
         bootstrap_snapshot = _btrfs_bootstrap_remote_to_local(src_dir, backup_path.parent)
         _, tmp_snapshot = _btrfs_take_snapshot_remote(src_dir, src_dir.with_path(src_dir.path.joinpath(backup_path.name)))
         _btrfs_send_receive_remote_to_local(tmp_snapshot, backup_path.parent, parent=bootstrap_snapshot)

--- a/tests/test_yaesm/test_backend/test_btrfsbackend.py
+++ b/tests/test_yaesm/test_backend/test_btrfsbackend.py
@@ -30,25 +30,32 @@ def test_do_backup(btrfs_backend, random_backup_generator, btrfs_fs, btrfs_sudo_
         assert len(backups) == timeframe.keep
         assert expected_backup_basenames[0:timeframe.keep] == backup_basenames
 
-def test_exec_backup_local_to_local(btrfs_backend, btrfs_fs, path_generator):
-    dst_dir = path_generator("test-dst-dir", base_dir=btrfs_fs, mkdir=True)
-    backup_path = dst_dir.joinpath("yaesm-foo-backup-hourly.1999_05_13_23:59")
-    assert not backup_path.is_dir()
-    btrfs_backend._exec_backup_local_to_local(btrfs_fs, backup_path)
-    assert backup_path.is_dir()
+def test_exec_backup_local_to_local(btrfs_backend, random_backup_generator, btrfs_fs):
+    backup = random_backup_generator(btrfs_fs, backup_type="local_to_local", dst_dir_base=btrfs_fs)
+    timeframe = backup.timeframes[0]
+    with freeze_time("1999-05-13 23:59"):
+        backup_path = backup.dst_dir.joinpath(f"yaesm-{backup.name}-{timeframe.name}.1999_05_13_23:59")
+        assert not backup_path.is_dir()
+        btrfs_backend._exec_backup_local_to_local(backup, timeframe)
+        assert backup_path.is_dir()
 
-def test_exec_backup_local_to_remote(btrfs_backend, sshtarget, btrfs_fs, btrfs_sudo_access, path_generator):
-    backup_path = sshtarget.with_path(path_generator("test-dst-dir", base_dir=btrfs_fs, mkdir=True).joinpath("yaesm-foo-backup-hourly.1999_05_13_23:59"))
-    assert not backup_path.path.is_dir()
-    btrfs_backend._exec_backup_local_to_remote(btrfs_fs, backup_path)
-    assert backup_path.path.is_dir()
+def test_exec_backup_local_to_remote(btrfs_backend, random_backup_generator, btrfs_fs, btrfs_sudo_access):
+    backup = random_backup_generator(btrfs_fs, backup_type="local_to_remote", dst_dir_base=btrfs_fs)
+    timeframe = backup.timeframes[0]
+    with freeze_time("1999-05-13 23:59"):
+        backup_path = backup.dst_dir.path.joinpath(f"yaesm-{backup.name}-{timeframe.name}.1999_05_13_23:59")
+        assert not backup_path.is_dir()
+        btrfs_backend._exec_backup_local_to_remote(backup, timeframe)
+        assert backup_path.is_dir()
 
-def test_exec_backup_remote_to_local(btrfs_backend, sshtarget, btrfs_fs, btrfs_sudo_access, path_generator):
-    src_dir = sshtarget.with_path(btrfs_fs)
-    backup_path = path_generator("test-dst-dir", base_dir=btrfs_fs, mkdir=True).joinpath("yaesm-foo-backup.1999_05_13_23:59")
-    assert not backup_path.is_dir()
-    btrfs_backend._exec_backup_remote_to_local(src_dir, backup_path)
-    assert backup_path.is_dir()
+def test_exec_backup_remote_to_local(btrfs_backend, random_backup_generator, btrfs_fs, btrfs_sudo_access):
+    backup = random_backup_generator(btrfs_fs, backup_type="remote_to_local", dst_dir_base=btrfs_fs)
+    timeframe = backup.timeframes[0]
+    with freeze_time("1999-05-13 23:59"):
+        backup_path = backup.dst_dir.joinpath(f"yaesm-{backup.name}-{timeframe.name}.1999_05_13_23:59")
+        assert not backup_path.is_dir()
+        btrfs_backend._exec_backup_remote_to_local(backup, timeframe)
+        assert backup_path.is_dir()
 
 def test_btrfs_take_and_delete_snapshot_local(btrfs_fs, path_generator):
     dst_dir1 = path_generator("test-snapshot", base_dir=btrfs_fs, mkdir=True)


### PR DESCRIPTION
This PR modifies the BackendBase class so it passes along the Backup and Timeframe object to its abstract methods (`_exec_backup_local_to_local()`, `exec_backup_local_to_remote()`, `exec_backup_remote_to_local()`). This is necessary for the Rsync backend (see #34) to be able to perform incremental backups efficiently, as it needs to find the previous backup (using `backups_collect()`).