### PR TITLE
Revert "Change time spec from HH:MM to HH-MM"

### DIFF
--- a/src/yaesm/config.py
+++ b/src/yaesm/config.py
@@ -300,7 +300,7 @@ class TimeframeSchema(Schema):
 
     @staticmethod
     def are_valid_timespecs(spec: list[str]) -> list[list[int, int]]:
-        """Takes a list of supposed timespecs. Returns a list of hour-minute pairings if
+        """Takes a list of supposed timespecs. Returns a list of hour:minute pairings if
         successful. This does NOT check if the hour and minute parts are valid, use
         `are_valid_hours` and `are_valid_minutes` to do this.
 
@@ -308,12 +308,12 @@ class TimeframeSchema(Schema):
         hour parts cannot be converted to `int`."""
         res = []
         for timespec in spec:
-            timespec_re = re.compile("^([0-9][0-9]?)-([0-9][0-9]?)$")
+            timespec_re = re.compile("([0-9]{2}):([0-9]{2})")
             if re_result := timespec_re.match(timespec):
                 res.append([int(re_result.group(1)), int(re_result.group(2))])
             else:
                 raise vlp.Invalid(TimeframeSchema.ErrMsg.TIME_MALFORMED
-                                  + f"\n\tExpected format 'hh-mm', got {timespec}")
+                                  + f"\n\tExpected format 'hh:mm', got {timespec}")
         return res
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,7 +394,7 @@ def random_timeframe_timespecs_generator():
             while timespec is None or timespec in timespecs:
                 hour = str(random.randint(0,23)).zfill(2)
                 minute = str(random.randint(0,59)).zfill(2)
-                timespec = f"{hour}-{minute}"
+                timespec = f"{hour}:{minute}"
             timespecs.append(timespec)
         return timespecs
     return generator
@@ -404,7 +404,7 @@ def random_timeframe_times_generator(random_timeframe_timespecs_generator):
     """Fixture to generate a list of random timeframe times."""
     def generator(num=3):
         timespecs = random_timeframe_timespecs_generator(num=num)
-        times = list(map(lambda x: tuple(map(int, x.split('-'))), timespecs))
+        times = list(map(lambda x: tuple(map(int, x.split(':'))), timespecs))
         return times
     return generator
 

--- a/tests/test_yaesm/test_config.py
+++ b/tests/test_yaesm/test_config.py
@@ -109,16 +109,16 @@ def test_TimeframeSchema_has_required_settings():
         + "\n\thourly: ['hourly_keep']"
 
 def test_TimeframeSchema_are_valid_timespecs():
-    valid_specs = ["12-34", "1-2", "23-59", "00-00", "99-99"]
-    valid_expected = [[12, 34], [1, 2], [23, 59], [0, 0], [99, 99]]
+    valid_specs = ["12:34", "23:59", "00:00", "99:99"]
+    valid_expected = [[12, 34], [23, 59], [0, 0], [99, 99]]
     assert config.TimeframeSchema.are_valid_timespecs(valid_specs) == valid_expected
 
-    invalid_specs = ["12:34", "1:23", "12:3", "ab-cd", "1234", ""]
+    invalid_specs = ["1:23", "12:3", "ab:cd", "1234", ""]
     for spec in invalid_specs:
         with pytest.raises(vlp.Invalid) as exc:
             config.TimeframeSchema.are_valid_timespecs([spec])
         assert str(exc.value) == config.TimeframeSchema.ErrMsg.TIME_MALFORMED \
-            + f"\n\tExpected format 'hh-mm', got {spec}"
+            + f"\n\tExpected format 'hh:mm', got {spec}"
 
 def test_TimeframeSchema_are_valid_hours():
     valid_specs = [[12, 34], [23, 59], [0, 0], [3, -1]]


### PR DESCRIPTION
Reverts Vultimate1/yaesm#58

I think were better off keeping the `HH:MM` time spec format, since its more understandable for users.