### PR TITLE
add btrfs bootstrap refresh config option (#26)

### DIFF
--- a/src/yaesm/backend/btrfsbackend.py
+++ b/src/yaesm/backend/btrfsbackend.py
@@ -2,10 +2,14 @@
 
 import shlex
 import subprocess
+import time
 from pathlib import Path
+
+import voluptuous as vlp
 
 import yaesm.backup as bckp
 from yaesm.backend.backendbase import BackendBase
+from yaesm.logging import Logging
 from yaesm.sshtarget import SSHTarget
 from yaesm.timeframe import Timeframe
 
@@ -24,6 +28,25 @@ class BtrfsBackend(BackendBase):
     'btrfs subvolume snapshot', 'btrfs subvolume delete', 'btrfs send', and
     'btrfs receive'.
     """
+
+    def __init__(self, extra_opts=None, bootstrap_refresh_days=None):
+        super().__init__(extra_opts)
+        self.bootstrap_refresh_days = bootstrap_refresh_days
+
+    @staticmethod
+    def config_schema() -> vlp.Schema:
+        def _apply_to_backend(d: dict) -> dict:
+            if "btrfs_bootstrap_refresh" in d:
+                d["backend"].bootstrap_refresh_days = d.pop("btrfs_bootstrap_refresh")
+            return d
+
+        return vlp.Schema(
+            vlp.All(
+                {vlp.Optional("btrfs_bootstrap_refresh"): vlp.All(int, vlp.Range(min=1))},
+                _apply_to_backend,
+            ),
+            extra=vlp.ALLOW_EXTRA,
+        )
 
     def check_extra(self, backup: bckp.Backup) -> list[str]:
         errors: list[str] = []
@@ -44,6 +67,8 @@ class BtrfsBackend(BackendBase):
     ) -> None:
         assert isinstance(backup.src_dir, Path)
         assert isinstance(backup.dst_dir, Path)
+        if self.bootstrap_refresh_days is not None:
+            _btrfs_maybe_refresh_bootstrap(backup, self.bootstrap_refresh_days)
         src_dir = backup.src_dir
         backup_path = backup.dst_dir.joinpath(bckp.backup_basename_now(backup, timeframe))
         returncode, _ = _btrfs_take_snapshot_local(src_dir, backup_path, check=False)
@@ -60,6 +85,8 @@ class BtrfsBackend(BackendBase):
     ) -> None:
         assert isinstance(backup.src_dir, Path)
         assert isinstance(backup.dst_dir, SSHTarget)
+        if self.bootstrap_refresh_days is not None:
+            _btrfs_maybe_refresh_bootstrap(backup, self.bootstrap_refresh_days)
         src_dir = backup.src_dir
         backup_path = backup.dst_dir.with_path(backup.dst_dir.path.joinpath(backup_basename))
         bootstrap_snapshot = _btrfs_bootstrap_local_to_remote(
@@ -78,6 +105,8 @@ class BtrfsBackend(BackendBase):
     ) -> None:
         assert isinstance(backup.src_dir, SSHTarget)
         assert isinstance(backup.dst_dir, Path)
+        if self.bootstrap_refresh_days is not None:
+            _btrfs_maybe_refresh_bootstrap(backup, self.bootstrap_refresh_days)
         src_dir = backup.src_dir
         backup_path = backup.dst_dir.joinpath(backup_basename)
         bootstrap_snapshot = _btrfs_bootstrap_remote_to_local(src_dir, backup_path.parent)
@@ -216,6 +245,45 @@ def _btrfs_send_receive_remote_to_local(
         check=check,
     )
     return p.returncode, dst_dir.joinpath(snapshot.path.name)
+
+
+def _btrfs_maybe_refresh_bootstrap(backup: bckp.Backup, refresh_days: int) -> None:
+    """Delete stale bootstrap snapshots so they get recreated fresh.
+
+    Checks if the src bootstrap snapshot is older than `refresh_days` days.
+    If so, deletes both src and dst bootstrap snapshots. The existing
+    _btrfs_bootstrap_* functions handle the "neither exists" case by
+    recreating both.
+    """
+    basename = _btrfs_bootstrap_snapshot_basename()
+    src_dir = backup.src_dir
+    dst_dir = backup.dst_dir
+    if isinstance(src_dir, SSHTarget):
+        src_bootstrap_path = src_dir.path.joinpath(basename)
+        src_bootstrap_target = src_dir.with_path(src_bootstrap_path)
+        if not src_bootstrap_target.is_dir():
+            return
+        mtime = src_bootstrap_target.mtime()
+    else:
+        src_bootstrap_path = src_dir.joinpath(basename)
+        if not src_bootstrap_path.is_dir():
+            return
+        mtime = src_bootstrap_path.stat().st_mtime
+    if time.time() - mtime <= refresh_days * 86400:
+        return
+    Logging.get().info(f"refreshing btrfs bootstrap snapshot for backup '{backup.name}'")
+    if isinstance(src_dir, SSHTarget):
+        _btrfs_delete_subvolumes_remote(src_bootstrap_target)
+    else:
+        _btrfs_delete_subvolumes_local(src_bootstrap_path)
+    if isinstance(dst_dir, SSHTarget):
+        dst_bootstrap_target = dst_dir.with_path(dst_dir.path.joinpath(basename))
+        if dst_bootstrap_target.is_dir():
+            _btrfs_delete_subvolumes_remote(dst_bootstrap_target)
+    else:
+        dst_bootstrap_path = dst_dir.joinpath(basename)
+        if dst_bootstrap_path.is_dir():
+            _btrfs_delete_subvolumes_local(dst_bootstrap_path)
 
 
 def _btrfs_bootstrap_snapshot_basename() -> str:

--- a/src/yaesm/sshtarget.py
+++ b/src/yaesm/sshtarget.py
@@ -168,6 +168,20 @@ class SSHTarget:
             == 0
         )
 
+    def mtime(self, f: Path | None = None) -> float:
+        """Return the mtime of `f` on the remote SSH server as epoch seconds.
+        If `f` is None then default to `self.path`.
+        """
+        if f is None:
+            f = self.path
+        p = subprocess.run(
+            self.openssh_cmd(f"stat -c %Y '{f}'"),
+            check=True,
+            capture_output=True,
+            encoding="utf-8",
+        )
+        return float(p.stdout.strip())
+
     def touch(self, f: Path | None = None, check: bool = True) -> bool:
         """Touch the file `f` on the remote SSH server. If `f` is None then default
         to `self.path`. The `check` arg is passed along to `subprocess.run()`. Return

--- a/tests/test_yaesm/test_backend/test_btrfsbackend.py
+++ b/tests/test_yaesm/test_backend/test_btrfsbackend.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
+import voluptuous as vlp
 from freezegun import freeze_time
 
 import yaesm.backend.btrfsbackend as btrfs
@@ -594,3 +595,232 @@ def test_check_remote_to_local_remote_src_not_readable(
     monkeypatch.setattr(subprocess, "run", fake_run)
     errors = btrfs_backend.check(backup)
     assert any("src_dir" in e and "not readable" in e for e in errors)
+
+
+# --- config_schema ---
+
+
+def test_config_schema():
+    schema = btrfs.BtrfsBackend.config_schema()
+    # accepts valid positive int and sets it on the backend instance
+    backend = btrfs.BtrfsBackend()
+    data = schema({"btrfs_bootstrap_refresh": 30, "backend": backend})
+    assert backend.bootstrap_refresh_days == 30
+    assert "btrfs_bootstrap_refresh" not in data
+    # accepts when not provided
+    backend2 = btrfs.BtrfsBackend()
+    data = schema({"backend": backend2})
+    assert backend2.bootstrap_refresh_days is None
+    # rejects non-int
+    with pytest.raises(vlp.Invalid):
+        schema({"btrfs_bootstrap_refresh": "thirty"})
+    # rejects zero
+    with pytest.raises(vlp.Invalid):
+        schema({"btrfs_bootstrap_refresh": 0})
+    # rejects negative
+    with pytest.raises(vlp.Invalid):
+        schema({"btrfs_bootstrap_refresh": -1})
+    # rejects float
+    with pytest.raises(vlp.Invalid):
+        schema({"btrfs_bootstrap_refresh": 1.5})
+
+
+# --- bootstrap refresh ---
+
+
+def _age_btrfs_snapshot(path, old_time):
+    """Set mtime on a readonly btrfs snapshot by temporarily making it writable."""
+    subprocess.run(["btrfs", "property", "set", str(path), "ro", "false"], check=True)
+    os.utime(path, (old_time, old_time))
+    subprocess.run(["btrfs", "property", "set", str(path), "ro", "true"], check=True)
+
+
+def test_btrfs_maybe_refresh_bootstrap(btrfs_fs_generator, random_timeframes_generator):
+    backend = btrfs.BtrfsBackend()
+    src_dir = btrfs_fs_generator()
+    dst_dir = btrfs_fs_generator()
+    backup = Backup("test-refresh", backend, src_dir, dst_dir, random_timeframes_generator())
+    basename = btrfs._btrfs_bootstrap_snapshot_basename()
+    src_bootstrap = src_dir.joinpath(basename)
+    dst_bootstrap = dst_dir.joinpath(basename)
+
+    # no bootstrap exists yet — should be a no-op
+    btrfs._btrfs_maybe_refresh_bootstrap(backup, 1)
+    assert not src_bootstrap.is_dir()
+    assert not dst_bootstrap.is_dir()
+
+    # create bootstrap snapshots manually
+    btrfs._btrfs_bootstrap_local_to_local(src_dir, dst_dir)
+    assert src_bootstrap.is_dir()
+    assert dst_bootstrap.is_dir()
+
+    # bootstrap is fresh — should not refresh
+    with freeze_time("2020-01-02 12:00"):
+        _age_btrfs_snapshot(src_bootstrap, datetime(2020, 1, 2).timestamp())
+        original_mtime = src_bootstrap.stat().st_mtime
+        btrfs._btrfs_maybe_refresh_bootstrap(backup, 1)
+    assert src_bootstrap.is_dir()
+    assert dst_bootstrap.is_dir()
+    assert src_bootstrap.stat().st_mtime == original_mtime
+
+    # age bootstrap past threshold — should delete both
+    with freeze_time("2020-01-05 12:00"):
+        _age_btrfs_snapshot(src_bootstrap, datetime(2020, 1, 1).timestamp())
+        btrfs._btrfs_maybe_refresh_bootstrap(backup, 1)
+    assert not src_bootstrap.is_dir()
+    assert not dst_bootstrap.is_dir()
+
+    # recreate and test: src deleted but dst already gone — no error
+    btrfs._btrfs_bootstrap_local_to_local(src_dir, dst_dir)
+    btrfs._btrfs_delete_subvolumes_local(dst_bootstrap)
+    assert not dst_bootstrap.is_dir()
+    with freeze_time("2020-01-05 12:00"):
+        _age_btrfs_snapshot(src_bootstrap, datetime(2020, 1, 1).timestamp())
+        btrfs._btrfs_maybe_refresh_bootstrap(backup, 1)
+    assert not src_bootstrap.is_dir()
+    assert not dst_bootstrap.is_dir()
+
+
+def test_bootstrap_refresh_local_to_local(btrfs_fs_generator, random_backup_generator):
+    backend = btrfs.BtrfsBackend(bootstrap_refresh_days=1)
+    backup = random_backup_generator(backend_type="btrfs", backup_type="local_to_local")
+    timeframe = backup.timeframes[0]
+    timeframe.keep = 5
+    with freeze_time("2020-01-01 12:00"):
+        backend.do_backup(backup, timeframe)
+    src_bootstrap = backup.src_dir.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    dst_bootstrap = backup.dst_dir.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    assert src_bootstrap.is_dir()
+    assert dst_bootstrap.is_dir()
+    _age_btrfs_snapshot(src_bootstrap, datetime(2020, 1, 1).timestamp())
+    old_mtime = src_bootstrap.stat().st_mtime
+    with freeze_time("2020-01-03 12:00"):
+        backend.do_backup(backup, timeframe)
+    assert src_bootstrap.is_dir()
+    assert dst_bootstrap.is_dir()
+    assert src_bootstrap.stat().st_mtime > old_mtime
+    # verify follow-up incremental backup works with the refreshed bootstrap
+    with freeze_time("2020-01-03 13:00"):
+        backend.do_backup(backup, timeframe)
+    assert len(bckp.backups_collect(backup, timeframe=timeframe)) == 3
+
+
+def test_bootstrap_refresh_local_to_remote(
+    btrfs_fs_generator, sshtarget_generator, random_backup_generator
+):
+    backend = btrfs.BtrfsBackend(bootstrap_refresh_days=1)
+    backup = random_backup_generator(backend_type="btrfs", backup_type="local_to_remote")
+    timeframe = backup.timeframes[0]
+    timeframe.keep = 5
+    with freeze_time("2020-01-01 12:00"):
+        backend.do_backup(backup, timeframe)
+    src_bootstrap = backup.src_dir.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    dst_bootstrap = backup.dst_dir.path.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    assert src_bootstrap.is_dir()
+    assert dst_bootstrap.is_dir()
+    _age_btrfs_snapshot(src_bootstrap, datetime(2020, 1, 1).timestamp())
+    old_mtime = src_bootstrap.stat().st_mtime
+    with freeze_time("2020-01-03 12:00"):
+        backend.do_backup(backup, timeframe)
+    assert src_bootstrap.is_dir()
+    assert dst_bootstrap.is_dir()
+    assert src_bootstrap.stat().st_mtime > old_mtime
+    # verify follow-up incremental backup works with the refreshed bootstrap
+    with freeze_time("2020-01-03 13:00"):
+        backend.do_backup(backup, timeframe)
+    assert len(bckp.backups_collect(backup, timeframe=timeframe)) == 3
+
+
+def test_bootstrap_refresh_remote_to_local(
+    btrfs_fs_generator, sshtarget_generator, random_backup_generator
+):
+    backend = btrfs.BtrfsBackend(bootstrap_refresh_days=1)
+    backup = random_backup_generator(backend_type="btrfs", backup_type="remote_to_local")
+    timeframe = backup.timeframes[0]
+    timeframe.keep = 5
+    with freeze_time("2020-01-01 12:00"):
+        backend.do_backup(backup, timeframe)
+    src_bootstrap = backup.src_dir.path.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    dst_bootstrap = backup.dst_dir.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    assert src_bootstrap.is_dir()
+    assert dst_bootstrap.is_dir()
+    _age_btrfs_snapshot(src_bootstrap, datetime(2020, 1, 1).timestamp())
+    old_mtime = src_bootstrap.stat().st_mtime
+    with freeze_time("2020-01-03 12:00"):
+        backend.do_backup(backup, timeframe)
+    assert src_bootstrap.is_dir()
+    assert dst_bootstrap.is_dir()
+    assert src_bootstrap.stat().st_mtime > old_mtime
+    # verify follow-up incremental backup works with the refreshed bootstrap
+    with freeze_time("2020-01-03 13:00"):
+        backend.do_backup(backup, timeframe)
+    assert len(bckp.backups_collect(backup, timeframe=timeframe)) == 3
+
+
+def test_bootstrap_no_refresh_when_young(btrfs_fs_generator, random_backup_generator):
+    backend = btrfs.BtrfsBackend(bootstrap_refresh_days=30)
+    backup = random_backup_generator(backend_type="btrfs", backup_type="local_to_local")
+    timeframe = backup.timeframes[0]
+    timeframe.keep = 5
+    with freeze_time("2020-01-01 12:00"):
+        backend.do_backup(backup, timeframe)
+    src_bootstrap = backup.src_dir.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    original_mtime = src_bootstrap.stat().st_mtime
+    with freeze_time("2020-01-02 12:00"):
+        backend.do_backup(backup, timeframe)
+    assert src_bootstrap.stat().st_mtime == original_mtime
+
+
+def test_bootstrap_no_refresh_at_boundary(btrfs_fs_generator, random_backup_generator):
+    backend = btrfs.BtrfsBackend(bootstrap_refresh_days=1)
+    backup = random_backup_generator(backend_type="btrfs", backup_type="local_to_local")
+    timeframe = backup.timeframes[0]
+    timeframe.keep = 5
+    with freeze_time("2020-01-01 12:00"):
+        backend.do_backup(backup, timeframe)
+    src_bootstrap = backup.src_dir.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    # age to exactly 1 day (== refresh_days), should NOT refresh
+    _age_btrfs_snapshot(src_bootstrap, datetime(2020, 1, 1, 12, 0).timestamp())
+    original_mtime = src_bootstrap.stat().st_mtime
+    with freeze_time("2020-01-02 12:00"):
+        backend.do_backup(backup, timeframe)
+    assert src_bootstrap.stat().st_mtime == original_mtime
+
+
+def test_bootstrap_no_refresh_when_unset(btrfs_fs_generator, random_backup_generator):
+    backend = btrfs.BtrfsBackend()
+    assert backend.bootstrap_refresh_days is None
+    backup = random_backup_generator(backend_type="btrfs", backup_type="local_to_local")
+    timeframe = backup.timeframes[0]
+    timeframe.keep = 5
+    with freeze_time("2020-01-01 12:00"):
+        backend.do_backup(backup, timeframe)
+    src_bootstrap = backup.src_dir.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    _age_btrfs_snapshot(src_bootstrap, datetime(2019, 1, 1).timestamp())
+    original_mtime = src_bootstrap.stat().st_mtime
+    with freeze_time("2020-05-01 12:00"):
+        backend.do_backup(backup, timeframe)
+    assert src_bootstrap.stat().st_mtime == original_mtime
+
+
+def test_bootstrap_refresh_preserves_existing_backups(btrfs_fs_generator, random_backup_generator):
+    backend = btrfs.BtrfsBackend(bootstrap_refresh_days=1)
+    backup = random_backup_generator(backend_type="btrfs", backup_type="local_to_local")
+    timeframe = backup.timeframes[0]
+    timeframe.keep = 10
+    now = datetime.now()
+    for i in range(3):
+        with freeze_time(now + timedelta(hours=i)):
+            backend.do_backup(backup, timeframe)
+    backups_before = bckp.backups_collect(backup, timeframe=timeframe)
+    assert len(backups_before) == 3
+    src_bootstrap = backup.src_dir.joinpath(btrfs._btrfs_bootstrap_snapshot_basename())
+    # set mtime to 2 days before the next frozen time
+    next_frozen = now + timedelta(hours=3)
+    _age_btrfs_snapshot(src_bootstrap, (next_frozen - timedelta(days=2)).timestamp())
+    with freeze_time(next_frozen):
+        backend.do_backup(backup, timeframe)
+    backups_after = bckp.backups_collect(backup, timeframe=timeframe)
+    assert len(backups_after) == 4
+    for b in backups_before:
+        assert b.is_dir()

--- a/tests/test_yaesm/test_config.py
+++ b/tests/test_yaesm/test_config.py
@@ -636,6 +636,39 @@ def test_BackupSchema_schema(valid_raw_config, path_generator):
         )
 
 
+def test_btrfs_bootstrap_refresh_config(path_generator):
+    schema = config.BackupSchema.schema()
+    src_dir = path_generator("src", mkdir=True)
+    dst_dir = path_generator("dst", mkdir=True)
+    data = {
+        "mybackup": {
+            "backend": "btrfs",
+            "btrfs_bootstrap_refresh": 30,
+            "src_dir": str(src_dir),
+            "dst_dir": str(dst_dir),
+            "timeframes": ["daily"],
+            "daily_keep": 7,
+            "daily_times": ["12:00"],
+        }
+    }
+    backup = schema(data)
+    assert backup.backend.bootstrap_refresh_days == 30
+
+    # without the setting, should default to None
+    data2 = {
+        "mybackup2": {
+            "backend": "btrfs",
+            "src_dir": str(src_dir),
+            "dst_dir": str(dst_dir),
+            "timeframes": ["daily"],
+            "daily_keep": 7,
+            "daily_times": ["12:00"],
+        }
+    }
+    backup2 = schema(data2)
+    assert backup2.backend.bootstrap_refresh_days is None
+
+
 def test_parse_config(path_generator, valid_config_file_generator):
     backups = config.parse_config(valid_config_file_generator())
     assert len(backups) == 3

--- a/tests/test_yaesm/test_sshtarget.py
+++ b/tests/test_yaesm/test_sshtarget.py
@@ -3,6 +3,8 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from yaesm.sshtarget import SSHTarget
 
 
@@ -163,3 +165,32 @@ def test_touch(sshtarget, path_generator):
     assert not path.is_file()
     assert newsshtarget.touch()
     assert path.is_file()
+
+
+def test_mtime(sshtarget, path_generator):
+    # file
+    path = path_generator("foo", cleanup=True)
+    path.touch()
+    target = sshtarget.with_path(path)
+    remote_mtime = target.mtime()
+    local_mtime = path.stat().st_mtime
+    assert abs(remote_mtime - local_mtime) < 1.0
+
+    # directory
+    d = path_generator("dir", cleanup=True, mkdir=True)
+    target_d = sshtarget.with_path(d)
+    remote_mtime_d = target_d.mtime()
+    local_mtime_d = d.stat().st_mtime
+    assert abs(remote_mtime_d - local_mtime_d) < 1.0
+
+    # explicit path argument
+    path2 = path_generator("bar", cleanup=True)
+    path2.touch()
+    remote_mtime2 = sshtarget.mtime(f=path2)
+    local_mtime2 = path2.stat().st_mtime
+    assert abs(remote_mtime2 - local_mtime2) < 1.0
+
+    # nonexistent path raises
+    bad_path = path_generator("nonexistent")
+    with pytest.raises(subprocess.CalledProcessError):
+        sshtarget.mtime(f=bad_path)


### PR DESCRIPTION
This PR solves issue #26. I added a new config option called `btrfs_bootstrap_refresh` to auto-refresh bootstrap snapshots when they are older than a specified threshold of days.