### PR TITLE
Add 'backup' subcommand for manual backups (#62)

### DIFF
--- a/src/yaesm/config.py
+++ b/src/yaesm/config.py
@@ -11,7 +11,7 @@ import yaesm.backup as bckp
 import yaesm.ty as ty
 from yaesm.backend import backendbase
 from yaesm.sshtarget import SSHTarget
-from yaesm.timeframe import tframe_types
+from yaesm.timeframe import tframe_types_configurable
 
 
 @dataclasses.dataclass
@@ -291,9 +291,7 @@ class TimeframeSchema(Schema):
                         list,
                         [
                             vlp.All(
-                                vlp.In(
-                                    ["5minute", "hourly", "daily", "weekly", "monthly", "yearly"]
-                                )
+                                vlp.In(tframe_types_configurable(names=True))
                             )
                         ],
                     )
@@ -426,7 +424,7 @@ class TimeframeSchema(Schema):
 
         The value paired with 'timeframes' in `spec` is assumed to be entirely valid.
         """
-        timeframe_dict = dict(zip(tframe_types(names=True), tframe_types()))
+        timeframe_dict = dict(zip(tframe_types_configurable(names=True), tframe_types_configurable()))
         timeframes = []
         for timeframe_name in spec["timeframes"]:
             timeframe_obj = timeframe_dict[timeframe_name](

--- a/src/yaesm/subcommand/backupsubcommand.py
+++ b/src/yaesm/subcommand/backupsubcommand.py
@@ -1,0 +1,44 @@
+import argparse
+import sys
+
+from yaesm.backup import Backup
+from yaesm.logging import Logging
+from yaesm.subcommand.subcommandbase import SubcommandBase
+from yaesm.timeframe import ImmediateTimeframe
+
+
+class BackupSubcommand(SubcommandBase):
+    """The backup subcommand performs a single manual backup."""
+
+    def main(self, backups: list[Backup], parsed_args: argparse.Namespace) -> int:
+        backup = None
+        for b in backups:
+            if b.name == parsed_args.backup_name:
+                backup = b
+                break
+        if backup is None:
+            Logging.get().error(f"backup not found: {parsed_args.backup_name}")
+            return 1
+
+        keep = parsed_args.keep if parsed_args.keep is not None else sys.maxsize
+        timeframe = ImmediateTimeframe(keep=keep)
+
+        Logging.get().info(f"starting backup '{backup.name}'")
+        try:
+            backup.backend.do_backup(backup, timeframe)
+        except Exception:
+            Logging.get().error(f"backup '{backup.name}' failed", exc_info=True)
+            return 1
+
+        Logging.get().info(f"backup '{backup.name}' completed successfully")
+        return 0
+
+    @classmethod
+    def add_argparser_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("backup_name", help="name of the backup from the config")
+        parser.add_argument(
+            "--keep",
+            type=int,
+            default=None,
+            help="maximum number of immediate backups to keep (default: unlimited)",
+        )

--- a/src/yaesm/timeframe.py
+++ b/src/yaesm/timeframe.py
@@ -31,6 +31,32 @@ def tframe_types(names: bool = False) -> list[str] | list[type[Timeframe]]:
     as strings. Otherwise return a list of all the timeframe type subclasses.
     """
     if names:
+        return ["5minute", "hourly", "daily", "weekly", "monthly", "yearly", "immediate"]
+    return [
+        FiveMinuteTimeframe,
+        HourlyTimeframe,
+        DailyTimeframe,
+        WeeklyTimeframe,
+        MonthlyTimeframe,
+        YearlyTimeframe,
+        ImmediateTimeframe,
+    ]
+
+
+@ty.overload
+def tframe_types_configurable(names: ty.Literal[True]) -> list[str]: ...
+
+
+@ty.overload
+def tframe_types_configurable(names: ty.Literal[False] = ...) -> list[type[Timeframe]]: ...
+
+
+def tframe_types_configurable(names: bool = False) -> list[str] | list[type[Timeframe]]:
+    """Like `tframe_types()` but only returns timeframe types that are valid in
+    configuration files. Excludes timeframes like `ImmediateTimeframe` that are
+    only used programmatically.
+    """
+    if names:
         return ["5minute", "hourly", "daily", "weekly", "monthly", "yearly"]
     return [
         FiveMinuteTimeframe,
@@ -158,3 +184,16 @@ class YearlyTimeframe(Timeframe):
     keep: int
     times: list[tuple[int, int]]
     yeardays: list[int]
+
+
+@dataclasses.dataclass
+class ImmediateTimeframe(Timeframe):
+    """`ImmediateTimeframe` represents a one-off manual backup triggered by the
+    ``yaesm backup`` subcommand.
+
+    This timeframe is not valid in configuration files and is excluded from
+    `tframe_types_configurable()`.
+    """
+
+    name = "immediate"
+    keep: int

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from yaesm.timeframe import (
     Timeframe,
     WeeklyTimeframe,
     YearlyTimeframe,
-    tframe_types,
+    tframe_types_configurable,
 )
 
 
@@ -432,7 +432,8 @@ def random_timeframe_generator(
         monthdays=None,
         yeardays=None,
     ) -> Timeframe:
-        tframe_type = random.choice(tframe_types()) if tframe_type is None else tframe_type
+        if tframe_type is None:
+            tframe_type = random.choice(tframe_types_configurable())
         keep = random.randint(1, 10) if keep is None else keep
         minutes = (
             random_timeframe_minutes_generator(random.randint(1, 5)) if minutes is None else minutes
@@ -486,7 +487,7 @@ def random_timeframes_generator(random_timeframe_generator):
 
     def generator(num=3, **kwargs):
         timeframes = []
-        tf_types = random.sample(tframe_types(), k=num)
+        tf_types = random.sample(tframe_types_configurable(), k=num)
         for tf_type in tf_types:
             timeframes.append(random_timeframe_generator(tframe_type=tf_type, **kwargs))
         return timeframes

--- a/tests/test_yaesm/test_config.py
+++ b/tests/test_yaesm/test_config.py
@@ -21,7 +21,7 @@ from yaesm.timeframe import (
     MonthlyTimeframe,
     Timeframe,
     WeeklyTimeframe,
-    tframe_types,
+    tframe_types_configurable,
 )
 
 
@@ -238,8 +238,8 @@ def test_TimeframeSchema_schema(valid_raw_config):
             if isinstance(backup_settings[key], list):
                 assert len(processed_backup[key]) == len(backup_settings[key])
 
-        tf_types = tframe_types()
-        tf_names = tframe_types(names=True)
+        tf_types = tframe_types_configurable()
+        tf_names = tframe_types_configurable(names=True)
         expected_tf_types = [
             tf_types[i]
             for i in range(len(tf_names))
@@ -269,6 +269,13 @@ def test_TimeframeSchema_schema(valid_raw_config):
                 assert [
                     isinstance(item, int) for time in processed_backup[setting] for item in time
                 ]
+
+
+def test_TimeframeSchema_rejects_immediate():
+    schema = config.TimeframeSchema.schema()
+    data = {"timeframes": ["immediate"]}
+    with pytest.raises(vlp.Invalid):
+        schema(data)
 
 
 def test_SrcDirDstDirSchema_is_sshtarget_spec():

--- a/tests/test_yaesm/test_subcommand/test_backupsubcommand.py
+++ b/tests/test_yaesm/test_subcommand/test_backupsubcommand.py
@@ -1,0 +1,150 @@
+import argparse
+import logging
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from freezegun import freeze_time
+
+import yaesm.backup as bckp
+from yaesm.backend.rsyncbackend import RsyncBackend
+from yaesm.subcommand.backupsubcommand import BackupSubcommand
+from yaesm.timeframe import ImmediateTimeframe
+
+
+@pytest.fixture
+def backupsubcommand():
+    return BackupSubcommand()
+
+
+@pytest.fixture(scope="session")
+def rsync_backend():
+    return RsyncBackend()
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser()
+    BackupSubcommand.add_argparser_arguments(parser)
+    return parser.parse_args(argv)
+
+
+def test_name():
+    assert BackupSubcommand.name() == "backup"
+
+
+def test_add_argparser_arguments():
+    args = _parse_args(["mybackup"])
+    assert args.backup_name == "mybackup"
+    assert args.keep is None
+
+
+def test_add_argparser_arguments_with_keep():
+    args = _parse_args(["mybackup", "--keep", "5"])
+    assert args.backup_name == "mybackup"
+    assert args.keep == 5
+
+
+def test_backup_name_not_found(backupsubcommand, caplog):
+    caplog.set_level(logging.ERROR)
+    args = _parse_args(["nonexistent"])
+    assert backupsubcommand.main([], args) == 1
+    assert "backup not found: nonexistent" in caplog.text
+
+
+def test_selects_correct_backup_from_multiple(backupsubcommand, caplog):
+    caplog.set_level(logging.INFO)
+    backup_a = MagicMock()
+    backup_a.name = "alpha"
+    backup_b = MagicMock()
+    backup_b.name = "bravo"
+    backup_c = MagicMock()
+    backup_c.name = "charlie"
+    args = _parse_args(["bravo"])
+    assert backupsubcommand.main([backup_a, backup_b, backup_c], args) == 0
+    backup_a.backend.do_backup.assert_not_called()
+    backup_b.backend.do_backup.assert_called_once()
+    backup_c.backend.do_backup.assert_not_called()
+    assert backup_b.backend.do_backup.call_args[0][0] is backup_b
+
+
+def test_successful_backup(backupsubcommand, caplog):
+    caplog.set_level(logging.INFO)
+    backup = MagicMock()
+    backup.name = "mybackup"
+    args = _parse_args(["mybackup"])
+    assert backupsubcommand.main([backup], args) == 0
+    backup.backend.do_backup.assert_called_once()
+    call_args = backup.backend.do_backup.call_args
+    assert call_args[0][0] is backup
+    tf = call_args[0][1]
+    assert isinstance(tf, ImmediateTimeframe)
+    assert tf.name == "immediate"
+    assert tf.keep == sys.maxsize
+    assert "starting backup" in caplog.text
+    assert "completed successfully" in caplog.text
+
+
+def test_successful_backup_with_keep(backupsubcommand, caplog):
+    caplog.set_level(logging.INFO)
+    backup = MagicMock()
+    backup.name = "mybackup"
+    args = _parse_args(["mybackup", "--keep", "3"])
+    assert backupsubcommand.main([backup], args) == 0
+    backup.backend.do_backup.assert_called_once()
+    tf = backup.backend.do_backup.call_args[0][1]
+    assert isinstance(tf, ImmediateTimeframe)
+    assert tf.keep == 3
+
+
+def test_backup_backend_exception(backupsubcommand, caplog):
+    caplog.set_level(logging.ERROR)
+    backup = MagicMock()
+    backup.name = "mybackup"
+    backup.backend.do_backup.side_effect = RuntimeError("boom")
+    args = _parse_args(["mybackup"])
+    assert backupsubcommand.main([backup], args) == 1
+    assert "failed" in caplog.text
+
+
+def test_backup_creates_immediate_named_directory(
+    backupsubcommand, rsync_backend, path_generator, caplog
+):
+    caplog.set_level(logging.INFO)
+    src_dir = path_generator("naming-src", mkdir=True)
+    dst_dir = path_generator("naming-dst", mkdir=True)
+    backup = bckp.Backup("testbackup", rsync_backend, src_dir, dst_dir, [])
+    args = _parse_args([backup.name])
+    with freeze_time("2026-03-23 14:30"):
+        assert backupsubcommand.main([backup], args) == 0
+    immediate_tf = ImmediateTimeframe(keep=sys.maxsize)
+    backups = bckp.backups_collect(backup, timeframe=immediate_tf)
+    assert len(backups) == 1
+    assert isinstance(backups[0], Path)
+    assert backups[0].name == "yaesm-testbackup-immediate.2026_03_23_14:30"
+
+
+def test_keep_deletes_old_immediate_backups(
+    backupsubcommand, rsync_backend, path_generator, caplog
+):
+    caplog.set_level(logging.INFO)
+    keep = 2
+    total = 5
+    src_dir = path_generator("keep-src", mkdir=True)
+    dst_dir = path_generator("keep-dst", mkdir=True)
+    backup = bckp.Backup("keeptest", rsync_backend, src_dir, dst_dir, [])
+    args = _parse_args([backup.name, "--keep", str(keep)])
+    now = datetime.now()
+    for i in range(total):
+        with freeze_time(now + timedelta(hours=i)):
+            assert backupsubcommand.main([backup], args) == 0
+    immediate_tf = ImmediateTimeframe(keep=keep)
+    remaining = bckp.backups_collect(backup, timeframe=immediate_tf)
+    assert len(remaining) == keep
+    # remaining should be the newest backups, sorted newest to oldest
+    for i, b in enumerate(remaining):
+        assert isinstance(b, Path)
+        expected_time = now + timedelta(hours=total - 1 - i)
+        expected_basename = expected_time.strftime(f"yaesm-{backup.name}-immediate.%Y_%m_%d_%H:%M")
+        assert b.name == expected_basename

--- a/tests/test_yaesm/test_timeframe.py
+++ b/tests/test_yaesm/test_timeframe.py
@@ -4,10 +4,12 @@ from yaesm.timeframe import (
     DailyTimeframe,
     FiveMinuteTimeframe,
     HourlyTimeframe,
+    ImmediateTimeframe,
     MonthlyTimeframe,
     WeeklyTimeframe,
     YearlyTimeframe,
     tframe_types,
+    tframe_types_configurable,
 )
 
 
@@ -55,6 +57,12 @@ def test_YearlyTimeframe():
     assert tf.yeardays == [1, 2, 365]
 
 
+def test_ImmediateTimeframe():
+    tf = ImmediateTimeframe(10)
+    assert tf.name == "immediate"
+    assert tf.keep == 10
+
+
 def test_tframe_types():
     assert tframe_types() == [
         FiveMinuteTimeframe,
@@ -63,5 +71,38 @@ def test_tframe_types():
         WeeklyTimeframe,
         MonthlyTimeframe,
         YearlyTimeframe,
+        ImmediateTimeframe,
     ]
-    assert tframe_types(names=True) == ["5minute", "hourly", "daily", "weekly", "monthly", "yearly"]
+    assert tframe_types(names=True) == [
+        "5minute",
+        "hourly",
+        "daily",
+        "weekly",
+        "monthly",
+        "yearly",
+        "immediate",
+    ]
+
+
+def test_tframe_types_configurable():
+    assert tframe_types_configurable() == [
+        FiveMinuteTimeframe,
+        HourlyTimeframe,
+        DailyTimeframe,
+        WeeklyTimeframe,
+        MonthlyTimeframe,
+        YearlyTimeframe,
+    ]
+    assert tframe_types_configurable(names=True) == [
+        "5minute",
+        "hourly",
+        "daily",
+        "weekly",
+        "monthly",
+        "yearly",
+    ]
+
+
+def test_ImmediateTimeframe_not_in_tframe_types_configurable():
+    assert ImmediateTimeframe not in tframe_types_configurable()
+    assert "immediate" not in tframe_types_configurable(names=True)


### PR DESCRIPTION
This PR solves issue #62.


This adds a `yaesm backup <backup_name>` subcommand so users can trigger a backup manually without going through the scheduler. It creates a new `ImmediateTimeframe` that slots into the existing backup infrastructure — backups get named with `immediate` in place of the usual timeframe name (e.g. `yaesm-mybackup-immediate.2026_03_23_14:30`), and the standard retention logic applies via an optional `--keep` flag. Without `--keep`, immediate backups accumulate indefinitely.
